### PR TITLE
Open SUMO page when the user clicks the notification

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,13 +1,38 @@
+const SUMO_PAGE = "https://support.mozilla.org/";
+
 browser.addonsRestrictedDomain.getDomain().then(async (domain) => {
   const matchPattern = `*://${domain}/*`;
+  const notificationId = "user-notification";
 
+  // This function is used to notify the user. Once the notification is
+  // displayed, the user can click on it to open a SUMO page (for more
+  // information).
   const showNotification = () => {
-    return browser.notifications.create({
+    return browser.notifications.create(notificationId, {
       type: "basic",
       title: browser.i18n.getMessage("notificationTitle"),
       message: browser.i18n.getMessage("notificationMessage", domain),
     });
   };
+
+  // This event listener is called when the user clicks the notification.
+  browser.notifications.onClicked.addListener(async (id) => {
+    if (id !== notificationId) {
+      return;
+    }
+
+    // We open the SUMO page in a new tab and, assuming the tab is created, we
+    // clear (hide) the notification. If the tab creation failed, likely on
+    // macOS because Firefox runs but without any window, we create a new
+    // window first, then we clear the notification.
+    try {
+      await browser.tabs.create({ url: SUMO_PAGE });
+    } catch {
+      await browser.windows.create({ url: SUMO_PAGE });
+    }
+
+    browser.notifications.clear(id);
+  });
 
   // Look at the existing tabs in case the target domain is already open. If
   // there are tabs, we show the notification and then we are done. Otherwise,


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/WEBEXT-1263

---

I think you're right, we'll need to add "click for more information" or something like that in the notification message. Also, I only tried on macOS, I don't know if that works on other platforms (I will find out eventually...).