### PR TITLE
[DONOTMERGE] Test updated version with two domains

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -1,6 +1,6 @@
 /* global ExtensionAPI, ExtensionCommon, Services */
 
-const DOMAINS = ["example.com"];
+const DOMAINS = ["example.com", "example.org"];
 const RESTRICTED_DOMAINS_PREF = "extensions.webextensions.restrictedDomains";
 
 const getArrayPref = (prefName) => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Add-ons Restricted Domains",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "hidden": true,
   "browser_specific_settings": {
     "gecko": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-restricted-domain",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-restricted-domains",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": "https://github.com/mozilla-extensions/addons-restricted-domains",
   "license": "MPLv2",
   "private": true,


### PR DESCRIPTION
This PR includes a version bump (from 1.0.0 to 1.1.0) and adds an additional domain (`example.org` in addition to `example.com` which was already in the base 1.0.0 version).

NOTE: This PR is not meant to be merged, its sole purpose is to get from the CI jobs a signed xpi file to share with QA for additional verification related to multiple domains and simulated updated version installed through balrog.